### PR TITLE
Add crystal version to shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,3 +8,5 @@ description: |
   Crystal sequence differencing implementation.
 
 license: MIT
+
+crystal: "*"


### PR DESCRIPTION
When the `crystal` version property is missing, the implicit meaning is `crystal: "< 1.0.0"`. Installing `crystal-diff` with crystal 1.0 conflicts. Even as 1.0 is not out yet, it's already relevant for nightly builds.

This is the minimal change to make it work. It would also be possible to define upper and/or lower bounds like `crystal: "< 2.0"` or `crystal: "> 0.10.0"` for example.